### PR TITLE
Fix interrupt stacks

### DIFF
--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -12,6 +12,8 @@ use x86_64::{
     PrivilegeLevel, VirtAddr,
 };
 
+use alloc::boxed::Box;
+
 pub use self::pit::HZ as PIT_HZ;
 
 mod pic;
@@ -72,7 +74,7 @@ pub fn init() {
         let stack = box Stack {
             _data: [0; IST_FRAME_SIZE],
         };
-        let stack_start = VirtAddr::from_ptr(&stack);
+        let stack_start = VirtAddr::from_ptr(Box::into_raw(stack));
         let stack_end = stack_start + IST_FRAME_SIZE;
         printk!("double fault stack @ {:?}, {:?}\n", stack_start, stack_end);
         stack_end
@@ -88,7 +90,7 @@ pub fn init() {
         let stack = box Stack {
             _data: [0; IST_FRAME_SIZE],
         };
-        let stack_start = VirtAddr::from_ptr(&stack);
+        let stack_start = VirtAddr::from_ptr(Box::into_raw(stack));
         let stack_end = stack_start + IST_FRAME_SIZE;
         printk!("irq stack @ {:?}, {:?}\n", stack_start, stack_end);
         stack_end

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -18,9 +18,8 @@ const STACK_WORDS: usize = 1 << 12; // 16KB
 static SCHEDULER: Mutex<Option<Scheduler>> = Mutex::new(None);
 
 /// The head of the current stack
-// TODO: maybe there is some race condition here? not really sure... I think the scheduler and the
-// syscall handler are the only ones using this, and by construction at most one of them can be
-// running at a time...
+// I think the scheduler and the syscall handler are the only ones using this,
+// and by construction at most one of them can be running at a time...
 static mut CURRENT_STACK_HEAD: u64 = 0;
 
 /// The kernel task scheduler


### PR DESCRIPTION
`VirtAddr::from_ptr(&stack)` returns `&stack as *const _` => some address on the stack instead of the kernel heap.
I ran into stack corruption while experimenting with your codebase and tracked it down to timer interrupts trashing the kernel stack.

:+1: for `os2` as a reference and I hope this saves you some time debugging :)